### PR TITLE
build: Bump Node.js to v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          version: '12.x'
+          version: '16.x'
       - run: npm ci
       - run: npm run build --if-exists
       - run: npm test

--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: true
 
 runs:
-  using: node12
+  using: node16
   main: "dist/index.js"


### PR DESCRIPTION
> as node12 is EOL since 2022-04-30.